### PR TITLE
Copy .env.example to .env

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,11 +1,14 @@
-TARGET_PATH = 'project-files/input/'
+"""
+This script will run after the project has been generated.
+Add any additional setup steps here.
+"""
+
+import os
 
 
-def download_files(course):
-    # This is just for testing purpose.
-    with open(f'{TARGET_PATH}{course}.txt', 'w') as f:
-        f.write(course)
+def create_env_file():
+    os.system('cp .env.example .env')
 
 
 if __name__ == '__main__':
-    download_files('{{ cookiecutter.course }}')
+    create_env_file()


### PR DESCRIPTION
Added a command to copy the example .env to the regular file to ensure infrastructure can be started right out.